### PR TITLE
Add document scheme to extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "zuulplugin" extension will be documented in this fil
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.1.4]
+
+- Warning fix: Add document scheme to extension as mentioned [here](https://code.visualstudio.com/api/references/document-selector#document-scheme).
+
 ## [0.1.3]
 
 - Bug fix: Parse jobs properly which have multi-line attributes and empty lines.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"publisher": "alexander-scott",
 	"repository": "https://github.com/Alexander-Scott/zuulplugin",
 	"description": "Navigate through Zuul Configuration more easily with this plugin.",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"engines": {
 		"vscode": "^1.44.0"
 	},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,25 +19,34 @@ export function activate(context: vscode.ExtensionContext) {
 	build_job_hierarchy();
 
 	context.subscriptions.push(
-		vscode.languages.registerCallHierarchyProvider("yaml", new JobHierarchyProvider(job_manager))
+		vscode.languages.registerCallHierarchyProvider(
+			{ scheme: "file", language: "yaml" },
+			new JobHierarchyProvider(job_manager)
+		)
 	);
 	context.subscriptions.push(
 		vscode.languages.registerDefinitionProvider(
-			"yaml",
+			{ scheme: "file", language: "yaml" },
 			new JobDefinitionProvider(job_manager, project_template_job_manager)
 		)
 	);
 	context.subscriptions.push(
-		vscode.languages.registerHoverProvider("yaml", new JobHoverProvider(job_manager, project_template_job_manager))
+		vscode.languages.registerHoverProvider(
+			{ scheme: "file", language: "yaml" },
+			new JobHoverProvider(job_manager, project_template_job_manager)
+		)
 	);
 	context.subscriptions.push(
 		vscode.languages.registerReferenceProvider(
-			"yaml",
+			{ scheme: "file", language: "yaml" },
 			new JobReferencesProvider(job_manager, project_template_job_manager)
 		)
 	);
 	context.subscriptions.push(
-		vscode.languages.registerDocumentSymbolProvider("yaml", new JobSymbolDocumentDefinitionsProvider(job_manager))
+		vscode.languages.registerDocumentSymbolProvider(
+			{ scheme: "file", language: "yaml" },
+			new JobSymbolDocumentDefinitionsProvider(job_manager)
+		)
 	);
 	context.subscriptions.push(
 		vscode.languages.registerWorkspaceSymbolProvider(new JobSymbolWorkspaceDefinitionsProvider(job_manager))


### PR DESCRIPTION
Fixes the following warning:

```
[2020-04-15 14:26:33.513] [exthost] [info] ExtensionService#loadCommonJSModule file:///home/q468121/.vscode-server/extensions/alexander-scott.zuulplugin-0.1.3/out/extension.js 
[2020-04-15 14:26:33.522] [exthost] [info] eager extensions activated 
[2020-04-15 14:26:33.609] [exthost] [info] Extension 'alexander-scott.zuulplugin' uses a document selector without scheme. Learn more about this: https://go.microsoft.com/fwlink/?linkid=872305 
[2020-04-15 14:26:33.909] [exthost] [info] Extension 'ms-python.python' uses a document selector without scheme. Learn more about this: https://go.microsoft.com/fwlink/?linkid=872305 
[2020-04-15 14:26:34.366] [exthost] [error] {"message":"Git error","stdout":"","stderr":"","exitCode":128} 
[2020-04-15 14:26:34.366] [exthost] [error] {"message":"Git error","stdout":"","stderr":"","exitCode":128} 
[2020-04-15 14:26:34.366] [exthost] [error] {"message":"Git error","stdout":"","stderr":"","exitCode":128} 
[2020-04-15 14:26:34.366] [exthost] [error] {"message":"Git error","stdout":"","stderr":"","exitCode":128}
```